### PR TITLE
add Gitcoin Data Portal

### DIFF
--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -31,7 +31,7 @@
    2. Perhaps we could invite them to speculate on RPGF?
 4. Novel directions in the [shape rotators guide to funding what matters](https://gov.gitcoin.co/t/shape-rotators-guide-to-funding-what-matters/17174).
 5. Simulation Models you can tune + run out of the box.
-6. Building things on top of well curated data models like [regendata.xyz](https://gov.gitcoin.co/t/regendata-xyz-our-sybil-resistant-future-q3-2023-and-beyond/16474) or OSObserver.
+6. Building things on top of well curated data models like [regendata.xyz](https://gov.gitcoin.co/t/regendata-xyz-our-sybil-resistant-future-q3-2023-and-beyond/16474), [Gitcoin-Grants-Data-Portal](https://github.com/davidgasquez/gitcoin-grants-data-portal) or OSObserver.
 
 
 Meta stuff (not object level, but about regenlearnings.xyz itself)


### PR DESCRIPTION
You likely know about this one, but putting it there so folks know they can get both raw and cleaned-up Gitcoin data in `.parquet` format from IPFS.