### PR TITLE
Fix broken link on learnings.mdx

### DIFF
--- a/pages/learnings.mdx
+++ b/pages/learnings.mdx
@@ -38,7 +38,7 @@
 
 ## Other Stuff
 - [In Defense of Liquid Democracy](https://dl.acm.org/doi/10.1145/3580507.3597817)
-- [Liquid Democracy in Practice](https://eaamo2022.eaamo.org/papers/revel-x1.pdf)
+- [Liquid Democracy in Practice](https://daniel-halpern.com/files/liquid-in-practice.pdf)
 - [State of Web3 Grants Report (2023)](https://docs.google.com/document/d/1CFD6ztSh2ggJSO-U3uEea92UVB1cRbvBlA1tfPxLKi8/edit)
 - [Exploring MycoFi: Mycelial Design Patterns for Web3 and Beyond](https://greenpill.network/pdf/mycofi.pdf)
 - [Introducing Random Donations: The YOLO of Public Goods Funding](https://blog.potlock.org/introducing-random-donations-the-yolo-of-public-goods-funding-3457d76d93cf)


### PR DESCRIPTION
Fix link to pdf for "Liquid democracy in practice". I found this pdf which is likely the same paper